### PR TITLE
fix(superconsole) use util.inspect instead of JSON.stringify

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
-    "name": "superconsole"
-  , "version": "1.0.0"
-  , "description": "Prepends handies informations before your logs as you wish.(timestamp, callsite, loglevel)"
-  , "main": "./superconsole"
-  , "dependencies": {
-      "callsite": "~1.0.0"
+    "name": "superconsole",
+    "version": "1.0.1",
+    "description": "Prepends handies informations before your logs as you wish.(timestamp, callsite, loglevel)",
+    "main": "./superconsole",
+    "dependencies": {
+        "callsite": "~1.0.0"
     }
 }

--- a/superconsole.js
+++ b/superconsole.js
@@ -5,6 +5,7 @@
 
 var stack = require('callsite')
   , tty = require('tty')
+  , util = require('util')
   , isatty = Boolean(tty.isatty() && process.stdout.getWindowSize)
   , defaultColors = { log: '90', error: '91', warn: '93', info: '96' , debug : '99' }
   , severityLevels = { debug : 7, log : 6, info : 5, warn : 4, error : 3}
@@ -31,7 +32,6 @@ module.exports = function (options) {
   }
 }
 
-
 /**
  * Overrides the console methods.
  */
@@ -54,7 +54,7 @@ module.exports = function (options) {
         } else if (arguments[0] instanceof Error){
           if(arguments[0].stack) arguments[0] = arguments[0].stack;
         } else if (typeof arguments[0] === 'object') {
-          arguments[0] = JSON.stringify(arguments[0], null, '  ');
+          arguments[0] = util.inspect(arguments[0]);
         }
         var pad = (arguments[0] && !console.traceOptions.right || !isatty ? ' ' : '');
         var _stack = stack();

--- a/test.js
+++ b/test.js
@@ -90,6 +90,20 @@ consoleMethods.forEach(function (name) {
 });
 
 require('./superconsole')({
+  callsite : true,
+  level : false,
+  timestamp : false
+});
+
+consoleMethods.forEach(function (name) {
+  process.stdout.write(' ');
+  var circular = {};
+  circular.circular = circular;
+  console[name]('this is a colored traced console.%s with callsite info only and circular object', name);
+  console[name](circular);
+});
+
+require('./superconsole')({
   callsite : false,
   level : false,
   timestamp : true


### PR DESCRIPTION
This is avoiding "Converting circular structure to JSON" errors.